### PR TITLE
Fix node version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Which version of Node image to use depends on project dependencies 
 # This is needed to build and compile our code 
 # while generating the docker image
-FROM node:14.15.0 AS build
+FROM node:18.10 AS build
 # Create a Virtual directory inside the docker image
 WORKDIR /dist/src/app
 # Copy files to virtual directory


### PR DESCRIPTION
Current Dockerfile causes:
```
 => ERROR [build 7/7] RUN ng build                                                                                                     0.4s
------
 > [build 7/7] RUN ng build:
#15 0.342 Node.js version v14.15.0 detected.
#15 0.342 The Angular CLI requires a minimum Node.js version of either v14.20, v16.13 or v18.10.
#15 0.342
#15 0.342 Please update your Node.js version or visit https://nodejs.org/ for additional instructions.
#15 0.342
------
executor failed running [/bin/sh -c ng build]: exit code: 3
```


This updates node to 18.10 which works